### PR TITLE
Compatibility with configuration sources used by other tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ This is useful if you `docker push` your images to Docker Hub. It provides an ea
 
 #### Required environment variables
 
-- `DOCKERHUB_USERNAME` - Docker Hub username. If updating a Docker Hub repository belonging to an organization, this user must have `Admin` permissions for the repository.
-- `DOCKERHUB_PASSWORD` - Docker Hub password.
-- `DOCKERHUB_REPOSITORY` - The Docker Hub repository to update in the format `<namespace>/<name>`. May also be passed as a secret if considered sensitive.
+- `DOCKERHUB_USERNAME` - Docker Hub username. If updating a Docker Hub repository belonging to an organization, this user must have `Admin` permissions for the repository. Aliases: `DOCKER_USERNAME`
+- `DOCKERHUB_PASSWORD` - Docker Hub password. Fallback to `DOCKER_PASSWORD` if set. Aliases: `DOCKER_PASSWORD`
+- `DOCKERHUB_REPOSITORY` - The Docker Hub repository to update in the format `<namespace>/<name>`. May also be passed as a secret if considered sensitive. Aliases: `DOCKER_REPOSITORY`, `GITHUB_REPOSITORY`
 
 **Note**: Docker Hub [Personal Access Tokens](https://docs.docker.com/docker-hub/access-tokens/) cannot be used as they are not supported by the API. See [here](https://github.com/docker/hub-feedback/issues/1927) and [here](https://github.com/docker/hub-feedback/issues/1914) for further details. Unfortunately, this means that enabling the new 2FA feature on Docker Hub will prevent the action from working.
 

--- a/action.yml
+++ b/action.yml
@@ -5,5 +5,15 @@ runs:
   using: 'docker'
   image: 'docker://peterevans/dockerhub-description:2.1.1'
 branding:
-  icon: 'upload'  
+  icon: 'upload'
   color: 'blue'
+inputs:
+  dockerhubUsername:
+    description: Username to login to Docker Hub. Aliases: DOCKER_USERNAME
+    required: false
+  dockerhubPassword:
+    description: Password to login to Docker Hub. Aliases: DOCKER_PASSWORD
+    required: false
+  dockerhubRepository:
+    description: Explicit Docker Hub repository name. Aliases: DOCKER_REPOSITORY, GITHUB_REPOSITORY
+    required: false

--- a/action.yml
+++ b/action.yml
@@ -4,13 +4,13 @@ description: 'An action to update a Docker Hub repository description from READM
 # env:
 #   DOCKERHUB_USERNAME:
 #     description: Username to login to Docker Hub. Aliases: DOCKER_USERNAME
-#     required: false
+#     required: true
 #   DOCKERHUB_PASSWORD:
 #     description: Password to login to Docker Hub. Aliases: DOCKER_PASSWORD
-#     required: false
+#     required: true
 #   DOCKERHUB_REPOSITORY:
 #     description: Explicit Docker Hub repository name. Aliases: DOCKER_REPOSITORY, GITHUB_REPOSITORY
-#     required: false
+#     required: true
 #   README_FILEPATH:
 #     description: Path to the repository readme.
 #     default: ./README.md

--- a/action.yml
+++ b/action.yml
@@ -1,19 +1,22 @@
 name: 'Docker Hub Description'
 author: 'Peter Evans'
 description: 'An action to update a Docker Hub repository description from README.md'
+# env:
+#   DOCKERHUB_USERNAME:
+#     description: Username to login to Docker Hub. Aliases: DOCKER_USERNAME
+#     required: false
+#   DOCKERHUB_PASSWORD:
+#     description: Password to login to Docker Hub. Aliases: DOCKER_PASSWORD
+#     required: false
+#   DOCKERHUB_REPOSITORY:
+#     description: Explicit Docker Hub repository name. Aliases: DOCKER_REPOSITORY, GITHUB_REPOSITORY
+#     required: false
+#   README_FILEPATH:
+#     description: Path to the repository readme.
+#     default: ./README.md
 runs:
   using: 'docker'
   image: 'docker://peterevans/dockerhub-description:2.1.1'
 branding:
   icon: 'upload'
   color: 'blue'
-inputs:
-  dockerhubUsername:
-    description: Username to login to Docker Hub. Aliases: DOCKER_USERNAME
-    required: false
-  dockerhubPassword:
-    description: Password to login to Docker Hub. Aliases: DOCKER_PASSWORD
-    required: false
-  dockerhubRepository:
-    description: Explicit Docker Hub repository name. Aliases: DOCKER_REPOSITORY, GITHUB_REPOSITORY
-    required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,26 @@
 #!/bin/sh -l
-set -euo pipefail
+set -eo pipefail
 IFS=$'\n\t'
+
+# Allow DOCKERHUB_* variables to be set from their DOCKER_* variant
+DOCKERHUB_USERNAME=${DOCKERHUB_USERNAME:-${DOCKER_USERNAME}}
+DOCKERHUB_PASSWORD=${DOCKERHUB_PASSWORD:-${DOCKER_PASSWORD}}
+DOCKERHUB_REPOSITORY=${DOCKERHUB_REPOSITORY:-${DOCKER_REPOSITORY}}
+
+# If the repository isn't explicitly defined, infer it from GitHub if possible
+DOCKERHUB_REPOSITORY=${DOCKERHUB_REPOSITORY:-${GITHUB_REPOSITORY}}
+
+# Validate we can authenticate
+if [ -z "$DOCKERHUB_USERNAME" ] || [ -z "$DOCKERHUB_PASSWORD" ]; then
+  echo 'Unable to authenticate with Docker Hub, set a valid $DOCKERHUB_USERNAME and $DOCKERHUB_PASSWORD'
+  exit 1
+fi
+
+# Validate we have the repository name
+if [ -z "$DOCKERHUB_REPOSITORY" ]; then
+  echo 'Unable to determine Docker Hub repository name, set with $DOCKERHUB_REPOSITORY'
+  exit 1
+fi
 
 # Set the default path to README.md
 README_FILEPATH=${README_FILEPATH:="./README.md"}


### PR DESCRIPTION
Let me know if I did anything wrong, but I hope this is useful - I know I would like it ;)

- Adds default support for the the environment variable `DOCKER_` prefix without having to explicitly override the preferred and documented `DOCKERHUB_` prefix, as both are extremely common across projects. This creates compatibility with other actions, tooling and documentation sources (i.e., [Build and Push Docker Images](https://github.com/marketplace/actions/build-and-push-docker-images), [Publish Docker](https://github.com/marketplace/actions/publish-docker), [CircleCI Document](https://medium.com/stepwise/pushing-docker-images-to-dockerhub-with-circleci-1b2e480e6ca)...) that prefer the other format, and saving the developer the need to have duplicate the secrets, and save users of the action the need to override such a common alternative.
- Falls back to `$GITHUB_REPOSITORY` (if available) if `DOCKER[HUB]_REPOSITORY` is not set or empty for users that use the same naming convention and user/organization for their projects (which is common). Saves the need to multiple developers to override this in their YAML.