### PR TITLE
Convert repository to lower case

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -152,6 +152,8 @@ function getInputs() {
     if (!inputs.repository && process.env['GITHUB_REPOSITORY']) {
         inputs.repository = process.env['GITHUB_REPOSITORY'];
     }
+    // Docker repositories must be all lower case
+    inputs.repository = inputs.repository.toLowerCase();
     return inputs;
 }
 exports.getInputs = getInputs;

--- a/src/input-helper.ts
+++ b/src/input-helper.ts
@@ -58,6 +58,9 @@ export function getInputs(): Inputs {
     inputs.repository = process.env['GITHUB_REPOSITORY']
   }
 
+  // Docker repositories must be all lower case
+  inputs.repository = inputs.repository.toLowerCase()
+
   return inputs
 }
 


### PR DESCRIPTION
DockerHub repository names must be all lower case.

Currently, it might not work for a repository where the Github username/organization contains capital letters.