### PR TITLE
Push image tags to docker hub

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -30,12 +30,17 @@ jobs:
           # Build and tag image
           docker build . --file Dockerfile --tag $IMAGE_NAME --label "org.opencontainers.image.version=$VERSION"
           docker tag $IMAGE_NAME $IMAGE_NAME:$VERSION
+          docker push $IMAGE_NAME:$VERSION
 
           # Tag with the minor version if valid
           MINOR_VERSION=$(echo $VERSION | sed -n "s/^\([0-9]*.[0-9]*\).[0-9]*$/\1/p")
-          [[ ${#MINOR_VERSION} -gt 0 ]] && docker tag $IMAGE_NAME $IMAGE_NAME:$MINOR_VERSION
+          if [[ ${#MINOR_VERSION} -gt 0 ]]; then
+            docker tag $IMAGE_NAME $IMAGE_NAME:$MINOR_VERSION
+            docker push $IMAGE_NAME:$MINOR_VERSION
+          fi
           # Tag with the major version if valid
           MAJOR_VERSION=$(echo $VERSION | sed -n "s/^\([0-9]*\).[0-9]*.[0-9]*$/\1/p")
-          [[ ${#MAJOR_VERSION} -gt 0 ]] && docker tag $IMAGE_NAME $IMAGE_NAME:$MAJOR_VERSION
-
-          docker push $IMAGE_NAME
+          if [[ ${#MAJOR_VERSION} -gt 0 ]]; then
+            docker tag $IMAGE_NAME $IMAGE_NAME:$MAJOR_VERSION
+            docker push $IMAGE_NAME:$MAJOR_VERSION
+          fi


### PR DESCRIPTION
Untested, but should fix #78

Version tags were not correctly pushed to docker hub (as `docker push [IMAGE]` only pushes the default tag, ie `latest`). This adds explicit calls to `docker push [IMAGE]:[VERSION]`.