### PR TITLE
fix: Used absolute path to index.js in entrypoint

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,9 @@
 #!/bin/sh -l
-set -eo pipefail
 IFS=$'\n\t'
 
 # Execute the action code and output to file
-node index.js > action.log 2>&1
+node /index.js > action.log 2>&1
+exit_code=$?
 
 # Remove lines containing sensitive information from the log
 sed -i '/::debug::/d' ./action.log
@@ -11,3 +11,6 @@ sed -i '/::add-mask::/d' ./action.log
 
 # Output the log
 cat action.log
+
+# Exit using the exit code of the node command
+exit $exit_code


### PR DESCRIPTION
When this image is used as a docker executor in CircleCI, the entrypoint gets disabled and the user has to explicitly invoke the entrypoint script. So the effective `docker run` command that gets executed would look something like below:

```
docker run --rm -v $PWD:/workspace \
              -e DOCKERHUB_PASSWORD \
              -e DOCKERHUB_USERNAME \
              -e DOCKERHUB_REPOSITORY='someuser/some-repo' \
              -e SHORT_DESCRIPTION='Some description' \
              -e README_FILEPATH='README.md' \
              -w /workspace \
              --entrypoint='' \
              peterevans/dockerhub-description:3.4.1 /entrypoint.sh
```

In such a case, the run fails with exit code `1` without displaying any error message. The contents of the `action.log`, when viewed manually, are below:

```
internal/modules/cjs/loader.js:818
  throw err;
  ^

Error: Cannot find module '/workspace/index.js'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:815:15)
    at Function.Module._load (internal/modules/cjs/loader.js:667:27)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:60:12)
    at internal/main/run_main_module.js:17:47 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}
```

Using an absolute path in the `node` command as `node /index.js` instead of `node index.js` fixes the above error. 

As for the container exiting before the error messages are displayed, it is due to the `set -e` line. To exit the container after displaying the errors, I have removed the `set -e` statement, captured the exit code of the `node` command which I have used as the exit code for the script after displaying the contents of `action.log`