### PR TITLE
Fix enable-url-completion input treating the string "false" as true

### DIFF
--- a/__test__/input-helper.unit.test.ts
+++ b/__test__/input-helper.unit.test.ts
@@ -1,4 +1,3 @@
-// import * as core from '@actions/core'
 import {getInputs} from '../src/input-helper'
 
 describe('input-helper tests', () => {

--- a/__test__/input-helper.unit.test.ts
+++ b/__test__/input-helper.unit.test.ts
@@ -26,11 +26,4 @@ describe('input-helper tests', () => {
     const inputs = getInputs()
     expect(inputs.enableUrlCompletion).toBe(true)
   })
-
-  test('enableUrlCompletion defaults to false if not set', () => {
-    delete process.env['INPUT_ENABLE-URL-COMPLETION']
-
-    const inputs = getInputs()
-    expect(inputs.enableUrlCompletion).toBe(false)
-  })
 })

--- a/__test__/input-helper.unit.test.ts
+++ b/__test__/input-helper.unit.test.ts
@@ -1,0 +1,36 @@
+// import * as core from '@actions/core'
+import {getInputs} from '../src/input-helper'
+
+describe('input-helper tests', () => {
+  const ORIGINAL_ENV = process.env
+
+  beforeEach(() => {
+    jest.resetModules()
+    process.env = {...ORIGINAL_ENV}
+  })
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV
+  })
+
+  test('enableUrlCompletion should be false when "false" is passed', () => {
+    process.env['INPUT_ENABLE-URL-COMPLETION'] = 'false'
+
+    const inputs = getInputs()
+    expect(inputs.enableUrlCompletion).toBe(false)
+  })
+
+  test('enableUrlCompletion should be true when "true" is passed', () => {
+    process.env['INPUT_ENABLE-URL-COMPLETION'] = 'true'
+
+    const inputs = getInputs()
+    expect(inputs.enableUrlCompletion).toBe(true)
+  })
+
+  test('enableUrlCompletion defaults to false if not set', () => {
+    delete process.env['INPUT_ENABLE-URL-COMPLETION']
+
+    const inputs = getInputs()
+    expect(inputs.enableUrlCompletion).toBe(false)
+  })
+})

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,7 @@ inputs:
     description: >
       Enables completion of relative URLs to absolute ones
       Default: `false`
+    default: "false"
   image-extensions:
     description: >
       File extensions that will be treated as images

--- a/dist/index.js
+++ b/dist/index.js
@@ -128,7 +128,7 @@ function getInputs() {
         repository: core.getInput('repository'),
         shortDescription: core.getInput('short-description'),
         readmeFilepath: core.getInput('readme-filepath'),
-        enableUrlCompletion: Boolean(core.getInput('enable-url-completion')),
+        enableUrlCompletion: core.getBooleanInput('enable-url-completion'),
         imageExtensions: core.getInput('image-extensions')
     };
     // Environment variable input alternatives and their aliases
@@ -157,7 +157,8 @@ function getInputs() {
         inputs.readmeFilepath = process.env['README_FILEPATH'];
     }
     if (!inputs.enableUrlCompletion && process.env['ENABLE_URL_COMPLETION']) {
-        inputs.enableUrlCompletion = Boolean(process.env['ENABLE_URL_COMPLETION']);
+        inputs.enableUrlCompletion =
+            process.env['ENABLE_URL_COMPLETION'].toLowerCase() === 'true';
     }
     if (!inputs.imageExtensions && process.env['IMAGE_EXTENSIONS']) {
         inputs.imageExtensions = process.env['IMAGE_EXTENSIONS'];
@@ -165,9 +166,6 @@ function getInputs() {
     // Set defaults
     if (!inputs.readmeFilepath) {
         inputs.readmeFilepath = readmeHelper.README_FILEPATH_DEFAULT;
-    }
-    if (!inputs.enableUrlCompletion) {
-        inputs.enableUrlCompletion = readmeHelper.ENABLE_URL_COMPLETION_DEFAULT;
     }
     if (!inputs.imageExtensions) {
         inputs.imageExtensions = readmeHelper.IMAGE_EXTENSIONS_DEFAULT;
@@ -313,13 +311,12 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.completeRelativeUrls = exports.getReadmeContent = exports.ENABLE_URL_COMPLETION_DEFAULT = exports.IMAGE_EXTENSIONS_DEFAULT = exports.README_FILEPATH_DEFAULT = void 0;
+exports.completeRelativeUrls = exports.getReadmeContent = exports.IMAGE_EXTENSIONS_DEFAULT = exports.README_FILEPATH_DEFAULT = void 0;
 const core = __importStar(__nccwpck_require__(7484));
 const fs = __importStar(__nccwpck_require__(9896));
 const utils = __importStar(__nccwpck_require__(9277));
 exports.README_FILEPATH_DEFAULT = './README.md';
 exports.IMAGE_EXTENSIONS_DEFAULT = 'bmp,gif,jpg,jpeg,png,svg,webp';
-exports.ENABLE_URL_COMPLETION_DEFAULT = false;
 const TITLE_REGEX = `(?: +"[^"]+")?`;
 const REPOSITORY_URL = `${process.env['GITHUB_SERVER_URL']}/${process.env['GITHUB_REPOSITORY']}`;
 const BLOB_PREFIX = `${REPOSITORY_URL}/blob/${process.env['GITHUB_REF_NAME']}/`;

--- a/src/input-helper.ts
+++ b/src/input-helper.ts
@@ -18,7 +18,7 @@ export function getInputs(): Inputs {
     repository: core.getInput('repository'),
     shortDescription: core.getInput('short-description'),
     readmeFilepath: core.getInput('readme-filepath'),
-    enableUrlCompletion: Boolean(core.getInput('enable-url-completion')),
+    enableUrlCompletion: core.getBooleanInput('enable-url-completion'),
     imageExtensions: core.getInput('image-extensions')
   }
 
@@ -54,7 +54,8 @@ export function getInputs(): Inputs {
   }
 
   if (!inputs.enableUrlCompletion && process.env['ENABLE_URL_COMPLETION']) {
-    inputs.enableUrlCompletion = Boolean(process.env['ENABLE_URL_COMPLETION'])
+    inputs.enableUrlCompletion =
+      process.env['ENABLE_URL_COMPLETION'].toLowerCase() === 'true'
   }
 
   if (!inputs.imageExtensions && process.env['IMAGE_EXTENSIONS']) {
@@ -64,9 +65,6 @@ export function getInputs(): Inputs {
   // Set defaults
   if (!inputs.readmeFilepath) {
     inputs.readmeFilepath = readmeHelper.README_FILEPATH_DEFAULT
-  }
-  if (!inputs.enableUrlCompletion) {
-    inputs.enableUrlCompletion = readmeHelper.ENABLE_URL_COMPLETION_DEFAULT
   }
   if (!inputs.imageExtensions) {
     inputs.imageExtensions = readmeHelper.IMAGE_EXTENSIONS_DEFAULT

--- a/src/readme-helper.ts
+++ b/src/readme-helper.ts
@@ -4,7 +4,6 @@ import * as utils from './utils'
 
 export const README_FILEPATH_DEFAULT = './README.md'
 export const IMAGE_EXTENSIONS_DEFAULT = 'bmp,gif,jpg,jpeg,png,svg,webp'
-export const ENABLE_URL_COMPLETION_DEFAULT = false
 
 const TITLE_REGEX = `(?: +"[^"]+")?`
 const REPOSITORY_URL = `${process.env['GITHUB_SERVER_URL']}/${process.env['GITHUB_REPOSITORY']}`


### PR DESCRIPTION
The `enable-url-completion` input is intended to default to false, but explicitly providing the string `"false"` (e.g. with `with: enable-url-completion: false` in yaml) mistakenly enables it. This happens because `Boolean("false")` in JavaScript is truthy.

This PR resolves the minor issue by using `core.getBooleanInput`, ensuring that `"false"` is correctly parsed as a boolean false, preserving the default behavior introduced by https://github.com/peter-evans/dockerhub-description/pull/125.
