### PR TITLE
Update create token endpoint

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -45,10 +45,10 @@ const fetch = __importStar(__nccwpck_require__(6705));
 function getToken(username, password) {
     return __awaiter(this, void 0, void 0, function* () {
         const body = {
-            username: username,
-            password: password
+            identifier: username,
+            secret: password
         };
-        const response = yield fetch('https://hub.docker.com/v2/users/login', {
+        const response = yield fetch('https://hub.docker.com/v2/auth/token', {
             method: 'post',
             body: JSON.stringify(body),
             headers: { 'Content-Type': 'application/json' }
@@ -75,7 +75,7 @@ function updateRepositoryDescription(token, repository, description, fullDescrip
             body: JSON.stringify(body),
             headers: {
                 'Content-Type': 'application/json',
-                Authorization: `JWT ${token}`
+                Authorization: `Bearer ${token}`
             }
         }).then(res => {
             if (!res.ok) {

--- a/src/dockerhub-helper.ts
+++ b/src/dockerhub-helper.ts
@@ -6,10 +6,10 @@ export async function getToken(
   password: string
 ): Promise<string> {
   const body = {
-    username: username,
-    password: password
+    identifier: username,
+    secret: password
   }
-  const response = await fetch('https://hub.docker.com/v2/users/login', {
+  const response = await fetch('https://hub.docker.com/v2/auth/token', {
     method: 'post',
     body: JSON.stringify(body),
     headers: {'Content-Type': 'application/json'}
@@ -41,7 +41,7 @@ export async function updateRepositoryDescription(
     body: JSON.stringify(body),
     headers: {
       'Content-Type': 'application/json',
-      Authorization: `JWT ${token}`
+      Authorization: `Bearer ${token}`
     }
   }).then(res => {
     if (!res.ok) {


### PR DESCRIPTION
[/v2/users/login](https://docs.docker.com/reference/api/hub/latest/#tag/authentication-api/operation/PostUsersLogin) was deprecated by Docker Hub in favor of using [/v2/auth/token](https://docs.docker.com/reference/api/hub/latest/#tag/authentication-api/operation/AuthCreateAccessToken) to create access tokens. Switching endpoints adds support for creating auth tokens using Organizational Access Tokens (OATs), but OATs still appear to lack sufficient permissions to alter repositories